### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/prospector.yml
+++ b/.github/workflows/prospector.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, master ]
 
+permissions:
+  contents: read
+
 jobs:
   prospector:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Anunnaki-Astronaut/RemoveSamples-NZBGet/security/code-scanning/3](https://github.com/Anunnaki-Astronaut/RemoveSamples-NZBGet/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Based on the steps in the workflow:
- The `actions/checkout` step requires `contents: read` to check out the repository code.
- The `actions/upload-artifact` step does not require additional permissions beyond the default `contents: read`.

We will add the following `permissions` block:
```yaml
permissions:
  contents: read
```

This ensures that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
