### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -1,5 +1,8 @@
 name: Manifest Check
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, master ]


### PR DESCRIPTION
Potential fix for [https://github.com/Anunnaki-Astronaut/RemoveSamples-NZBGet/security/code-scanning/1](https://github.com/Anunnaki-Astronaut/RemoveSamples-NZBGet/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly set the required permissions. Since the workflow only reads the `manifest.json` file and validates its syntax, the `contents: read` permission is sufficient. This change ensures that the workflow does not inadvertently inherit elevated permissions from the repository.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
