### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, master ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Anunnaki-Astronaut/RemoveSamples-NZBGet/security/code-scanning/2](https://github.com/Anunnaki-Astronaut/RemoveSamples-NZBGet/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function. Since the workflow only reads repository contents and does not perform any write operations, we can set `contents: read` as the permission. This ensures that the `GITHUB_TOKEN` has minimal access.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `test` job. In this case, adding it at the root level is more concise and ensures consistency across all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
