### PR TITLE
ci: add TruffleHog secret scanning

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -1,0 +1,31 @@
+name: Secret scanning
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+  workflow_dispatch:
+  schedule:
+    - cron: '17 3 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  trufflehog:
+    name: TruffleHog
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Scan for leaked credentials
+        uses: trufflesecurity/trufflehog@6f3c981e7b77f235fd2702dd74af25fc4b72bf11 # v3.96.0
+        with:
+          version: v3.96.0
+          extra_args: --results=verified,unknown

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -27,5 +27,5 @@ jobs:
       - name: Scan for leaked credentials
         uses: trufflesecurity/trufflehog@6f3c981e7b77f235fd2702dd74af25fc4b72bf11 # v3.96.0
         with:
-          version: v3.96.0
+          version: 3.96.0
           extra_args: --results=verified,unknown


### PR DESCRIPTION
## What changed

- Add TruffleHog scanning for pushes and pull requests targeting `main`/`master`
- Add manual dispatch and weekly full-history scans
- Use read-only contents permission
- Pin the TruffleHog action to the v3.96.0 release commit

## Verification

- Existing unittest suite: 16/16 passed locally
- Workflow YAML parsed and required markers verified
- Pre-existing `.graphifyignore` was not included
- Corrected the TruffleHog container image tag after the initial run exposed a `v3.96.0` versus `3.96.0` registry-tag mismatch
- Remote TruffleHog check passed after the correction

The workflow does not use repository secrets or elevated permissions.